### PR TITLE
fix(logger): add ANSI support for terminal to fix incorrect output

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -6,10 +6,8 @@ from typing import Union
 
 from rich.console import Console
 from rich.markup import escape
-from rich.traceback import install
 
 console = Console()
-install(show_locals=True)
 
 
 def delay(wait=1):
@@ -53,6 +51,11 @@ class Logger:
         # logger signal is used to output log to logger box or other output
         self.logs = ""
         self.logger_signal = logger_signal
+        if not self.logger_signal:
+            # if the logger signal is not configured, we use rich traceback then
+            # to better display error messages in console
+            from rich.traceback import install
+            install(show_locals=True)
         self.logger = logging.getLogger("BAAS_Logger")
         formatter = logging.Formatter("%(levelname)8s |%(asctime)20s | %(message)s ")
         handler1 = logging.StreamHandler(stream=sys.stdout)
@@ -68,6 +71,9 @@ class Logger:
         :return: None
         """
         # If raw_print is True, output log to logger box
+        if level < 1 or level > 4:
+            raise ValueError("Invalid log level")
+
         if raw_print:
             self.logs += message
             if self.logger_signal:

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,8 +1,15 @@
 import logging
 import sys
 import threading
-from typing import Union
 from datetime import datetime, timedelta, timezone
+from typing import Union
+
+from rich.console import Console
+from rich.markup import escape
+from rich.traceback import install
+
+console = Console()
+install(show_locals=True)
 
 
 def delay(wait=1):
@@ -25,10 +32,13 @@ def delay(wait=1):
 
     return decorator
 
+
 def detach(func):
     def wrapper(*args, **kwargs):
         threading.Thread(target=func, args=args[:-1], kwargs=kwargs).start()
+
     return wrapper
+
 
 class Logger:
     """
@@ -37,10 +47,10 @@ class Logger:
 
     def __init__(self, logger_signal):
         """
-        :param logger_signal: Logger Box signal
+        :param logger_signal: Logger signal broadcasts log level and log message
         """
-        # Init logger box signal, logs and logger
-        # logger box signal is used to output log to logger box
+        # Init logger signal, logs and logger,
+        # logger signal is used to output log to logger box or other output
         self.logs = ""
         self.logger_signal = logger_signal
         self.logger = logging.getLogger("BAAS_Logger")
@@ -54,38 +64,30 @@ class Logger:
         """
         Output log
         :param message: log message
-        :param level: log level
+        :param level: log level(1: INFO, 2: WARNING, 3: ERROR, 4: CRITICAL)
         :return: None
         """
         # If raw_print is True, output log to logger box
         if raw_print:
             self.logs += message
-            self.logger_signal.emit(message)
+            self.logger_signal.emit(level, message)
             return
 
         while len(logging.root.handlers) > 0:
             logging.root.handlers.pop()
-        # Status Text: INFO, WARNING, ERROR, CRITICAL
-        status = ['&nbsp;&nbsp;&nbsp;&nbsp;INFO', '&nbsp;WARNING', '&nbsp;&nbsp;&nbsp;ERROR', 'CRITICAL']
-        # Status Color: Blue, Orange, Red, Purple
-        statusColor = ['#2d8cf0', '#f90', '#ed3f14', '#3e0480']
-        # Status HTML: <b style="color:$color">status</b>
-        statusHtml = [
-            f'<b style="color:{_color};">{status}</b>'
-            for _color, status in zip(statusColor, status)]
-        # If logger box is not None, output log to logger box
+
+        levels_str = ["INFO", "WARNING", "ERROR", "CRITICAL"]
+        # If logger signal is not None, output log to logger signal
         # else output log to console
+        levels_color = ["#2d8cf0", "#ff9900", "#ed3f14", "#3e0480"]
         if self.logger_signal is not None:
-            message = message.replace('\n', '<br>').replace(' ', '&nbsp;')
-            adding = (f'''
-                    <div style="font-family: Consolas, monospace;color:{statusColor[level - 1]};">
-                        {statusHtml[level - 1]} | {datetime.now().strftime("%Y-%m-%d %H:%M:%S")} | {message}
-                    </div>
-                        ''')
-            self.logs += adding
-            self.logger_signal.emit(adding)
+            self.logs += f"{levels_str[level - 1]} |{datetime.now().strftime("%Y-%m-%d %H:%M:%S")}| {message}"
+            self.logger_signal.emit(level, message)
         else:
-            print(f'{statusHtml[level - 1]} | {datetime.now().strftime("%Y-%m-%d %H:%M:%S")} | {message}')
+            console.print(f'[{levels_color[level - 1]}]'
+                          f'{levels_str[level - 1]} |'
+                          f' {datetime.now().strftime("%Y-%m-%d %H:%M:%S")} |'
+                          f' {escape(message)}[/]', soft_wrap=True)
 
     def info(self, message: str) -> None:
         """
@@ -226,6 +228,7 @@ def is_nearby_group(coord, group, abs_x=10, abs_y=10):
             return True
     return False
 
+
 def get_nearest_hour(target_hour):
     now = datetime.now(timezone.utc)
     current_hour = now.hour
@@ -235,7 +238,7 @@ def get_nearest_hour(target_hour):
             hour_delta = diff - 24
         else:
             hour_delta = diff
-    else:   # target_hour < current_hour
+    else:  # target_hour < current_hour
         diff = current_hour - target_hour
         if diff > 12:
             hour_delta = 24 - diff
@@ -244,4 +247,3 @@ def get_nearest_hour(target_hour):
 
     nearest_time = (now + timedelta(hours=hour_delta)).replace(minute=0, second=0, microsecond=0)
     return nearest_time
-

--- a/core/utils.py
+++ b/core/utils.py
@@ -70,7 +70,8 @@ class Logger:
         # If raw_print is True, output log to logger box
         if raw_print:
             self.logs += message
-            self.logger_signal.emit(level, message)
+            if self.logger_signal:
+                self.logger_signal.emit(level, message)
             return
 
         while len(logging.root.handlers) > 0:
@@ -81,7 +82,7 @@ class Logger:
         # else output log to console
         levels_color = ["#2d8cf0", "#ff9900", "#ed3f14", "#3e0480"]
         if self.logger_signal is not None:
-            self.logs += f"{levels_str[level - 1]} |{datetime.now().strftime("%Y-%m-%d %H:%M:%S")}| {message}"
+            self.logs += f"{levels_str[level - 1]} | {datetime.now().strftime("%Y-%m-%d %H:%M:%S")} | {message}"
             self.logger_signal.emit(level, message)
         else:
             console.print(f'[{levels_color[level - 1]}]'

--- a/gui/fragments/home.py
+++ b/gui/fragments/home.py
@@ -1,3 +1,4 @@
+import html
 import json
 import sys
 import time
@@ -161,24 +162,37 @@ class HomeFragment(QFrame):
 
     @pyqtSlot(int, str)
     def on_log_received(self, level: int, message: str) -> None:
+        """
+         Slot handler for receiving log messages from the logger signal.
+
+         Formats log messages with HTML styling including colored status indicators,
+         timestamps, and appropriate color coding before displaying in the logger box.
+
+         Args:
+             level: Log level (1=INFO, 2=WARNING, 3=ERROR, 4=CRITICAL)
+             message: The log message to display
+         """
         try:
-            # Status Text: INFO, WARNING, ERROR, CRITICAL
-            status = ['&nbsp;&nbsp;&nbsp;&nbsp;INFO', '&nbsp;WARNING', '&nbsp;&nbsp;&nbsp;ERROR', 'CRITICAL']
-            # Status Color: Blue, Orange, Red, Purple
-            statusColor = ['#2d8cf0', '#f90', '#ed3f14', '#3e0480']
+            # Level Text: INFO, WARNING, ERROR, CRITICAL
+            levels_str = ['&nbsp;&nbsp;&nbsp;&nbsp;INFO', '&nbsp;WARNING', '&nbsp;&nbsp;&nbsp;ERROR', 'CRITICAL']
+            # Level Color: Blue, Orange, Red, Purple
+            levels_color = ['#2d8cf0', '#ff9900', '#ed3f14', '#3e0480']
             # Status HTML: <b style="color:$color">status</b>
-            statusHtml = [
+            status_html = [
                 f'<b style="color:{_color};">{status}</b>'
-                for _color, status in zip(statusColor, status)]
+                for _color, status in zip(levels_color, levels_str)]
+            message = html.escape(message)  # additional escape to prevent XSS injection
             message = message.replace('\n', '<br>').replace(' ', '&nbsp;')
             adding = (f'''
-                                <div style="font-family: Consolas, monospace;color:{statusColor[level - 1]};">
-                                    {statusHtml[level - 1]} | {datetime.now().strftime("%Y-%m-%d %H:%M:%S")} | {message}
+                                <div style="font-family: Consolas, monospace;color:{levels_color[level - 1]};">
+                                    {status_html[level - 1]} | {datetime.now().strftime("%Y-%m-%d %H:%M:%S")} | {message}
                                 </div>
                                     ''')
             self.logger_box.append(adding)
         except Exception as e:
+            import traceback
             print(f"Error when printing to log box: {e}")
+            traceback.print_exc()
 
     def _change_hotkey(self, key: str):
         """Handles the logic for changing a hotkey via the dialog."""

--- a/gui/fragments/home.py
+++ b/gui/fragments/home.py
@@ -1,12 +1,13 @@
-import sys
 import json
+import sys
 import time
-from random import random
-from typing import Callable
+from datetime import datetime
 from hashlib import md5
 from json import JSONDecodeError
+from random import random
+from typing import Callable
 
-from PyQt5.QtCore import Qt, QThread, pyqtSignal
+from PyQt5.QtCore import Qt, QThread, pyqtSignal, pyqtSlot
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import QFrame, QVBoxLayout, QLabel, QHBoxLayout, QWidget
 from qfluentwidgets import FluentIcon as FIF, TextEdit, SwitchButton, IndicatorPosition, PushButton
@@ -22,6 +23,7 @@ from window import Window
 
 if sys.platform == "win32":
     from gui.util.hotkey_manager import GlobalHotkeyManager, HotkeyInputDialog
+
     _Callback = Callable[[], None]
 
 MAIN_BANNER = 'gui/assets/banner_home_bg.png'
@@ -111,7 +113,7 @@ class HomeFragment(QFrame):
         self.main_thread_attach = MainThread(self.config)
         self.config.set_main_thread(self.main_thread_attach)
         self.main_thread_attach.button_signal.connect(self.set_button_state)
-        self.main_thread_attach.logger_signal.connect(self.logger_box.append)
+        self.main_thread_attach.logger_signal.connect(self.on_log_received)
         self.main_thread_attach.update_signal.connect(self.call_update)
         self.main_thread_attach.exit_signal.connect(lambda x: sys.exit(x))
 
@@ -150,13 +152,33 @@ class HomeFragment(QFrame):
             }
             self.hotkey_push_button.clicked.connect(lambda _: self._change_hotkey(ht_k))
 
-
         self.startup_card.clicked.connect(self._start_clicked)
         # set a hash object name for this widget
         self.object_name = md5(f'{time.time()}%{random()}'.encode('utf-8')).hexdigest()
         self.setObjectName(f"{self.object_name}.HomeFragment")
         if self.config.get('autostart'):
             self.startup_card.button.click()
+
+    @pyqtSlot(int, str)
+    def on_log_received(self, level: int, message: str) -> None:
+        try:
+            # Status Text: INFO, WARNING, ERROR, CRITICAL
+            status = ['&nbsp;&nbsp;&nbsp;&nbsp;INFO', '&nbsp;WARNING', '&nbsp;&nbsp;&nbsp;ERROR', 'CRITICAL']
+            # Status Color: Blue, Orange, Red, Purple
+            statusColor = ['#2d8cf0', '#f90', '#ed3f14', '#3e0480']
+            # Status HTML: <b style="color:$color">status</b>
+            statusHtml = [
+                f'<b style="color:{_color};">{status}</b>'
+                for _color, status in zip(statusColor, status)]
+            message = message.replace('\n', '<br>').replace(' ', '&nbsp;')
+            adding = (f'''
+                                <div style="font-family: Consolas, monospace;color:{statusColor[level - 1]};">
+                                    {statusHtml[level - 1]} | {datetime.now().strftime("%Y-%m-%d %H:%M:%S")} | {message}
+                                </div>
+                                    ''')
+            self.logger_box.append(adding)
+        except Exception as e:
+            print(f"Error when printing to log box: {e}")
 
     def _change_hotkey(self, key: str):
         """Handles the logic for changing a hotkey via the dialog."""
@@ -264,7 +286,6 @@ class HomeFragment(QFrame):
         self.hk_mgr.register(bind_key, callback)
         self.hk_mgr.start()
 
-
     # def __init_starter(self):
     # if self._main_thread is None:
     #     from main import Main
@@ -284,7 +305,7 @@ class HomeFragment(QFrame):
 
 class MainThread(QThread):
     button_signal = pyqtSignal(str)
-    logger_signal = pyqtSignal(str)
+    logger_signal = pyqtSignal(int, str)
     update_signal = pyqtSignal(list)
     exit_signal = pyqtSignal(int)
 
@@ -431,5 +452,3 @@ class MainThread(QThread):
 
     def get_baas_thread(self):
         return self._main_thread
-
-

--- a/gui/fragments/home.py
+++ b/gui/fragments/home.py
@@ -2,6 +2,7 @@ import html
 import json
 import sys
 import time
+import traceback
 from datetime import datetime
 from hashlib import md5
 from json import JSONDecodeError
@@ -190,7 +191,6 @@ class HomeFragment(QFrame):
                                     ''')
             self.logger_box.append(adding)
         except Exception as e:
-            import traceback
             print(f"Error when printing to log box: {e}")
             traceback.print_exc()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "tomli==2.3.0",
     "tomli_w==1.2.0",
     "PyAutoGUI==0.9.54",
-    "mss==10.1.0"
+    "mss==10.1.0",
+    "rich>=14.2.0",
 ]
 requires-python = ">=3.14"
 readme = "README.md"

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -13,3 +13,4 @@ psutil~=7.1.0
 tomli==2.3.0
 tomli_w~=1.2.0
 lxml~=6.0.2
+rich>=14.2.0

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -13,5 +13,6 @@ psutil~=7.1.0
 tomli==2.3.0
 tomli_w==1.2.0
 lxml~=6.0.2
+rich>=14.2.0
 
 win11toast~=0.36.2


### PR DESCRIPTION
Refactor logger output to enhance readability and visual distinction across both the GUI and console.

The GUI now uses an `on_log_received` slot to format log messages with colored status indicators, timestamps, and HTML styling before displaying them in the logger box. This makes it easier to identify log levels (INFO, WARNING, ERROR, CRITICAL) at a glance.

The core `Logger` class in `core/utils.py` has been updated to emit the raw log level and message, decoupling formatting concerns from the logger's core functionality. This allows different consumers, like the GUI or console, to apply their specific presentation logic.

For console output, the `rich` library has been integrated, providing colored and structured logging directly to the terminal for improved developer experience. The `rich` library has been added to the project dependencies.

BREAKING-CHANGE: changed the usage of logger_signal from pyqtSignal(str) to pyqtSignal(int, str)


引入了 Rich 库 来实现Terminal的输出优化
该方案使用 Rich库重构 utils.py，理论上支持所有操作系统。
该PR修复了长久以来的terminal输出问题，长久以来，baas直接将html格式的文本输出至terminal，为优化开发体验，该项PR:
- 将html格式化的任务移至 qt gui内部，并且将 logger_signal 设置为 (level:int,message:str)，方便于后期的迁移
- 在terminal层面，实现与window相同的颜色输出
- 在debug层面，使用rich自带功能实现更清晰的exception输出

注：你仍可能需要在Pycharm中设置模拟终端才能完整体验rich功能
效果演示：
- Pycharm (before):
<img width="1802" height="548" alt="image" src="https://github.com/user-attachments/assets/e8e22cf9-7b94-468f-95ed-270a54f29ff0" />
- Pycharm (after):
<img width="1800" height="582" alt="image" src="https://github.com/user-attachments/assets/8ac0f6d3-91fa-4b2c-bd28-0b01f5481144" />
exception直观展示：
<img width="1679" height="684" alt="image" src="https://github.com/user-attachments/assets/aeb91d8e-7b01-40ef-807e-8608b575a521" />
- Windows Terminal(before):
<img width="1480" height="758" alt="image" src="https://github.com/user-attachments/assets/06e93690-d995-4f60-8a97-3c287e976c30" />
- Windows Terminal(after):
<img width="1474" height="758" alt="image" src="https://github.com/user-attachments/assets/a0b8e9bd-03d5-4c46-b6ee-1e3efa2bb12f" />

